### PR TITLE
Feature/yfinance currency ticker handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   "trading_ig",
   "riskfolio-lib",
   "tenacity",
+  "pycountry",
 ]
 
 [dependency-groups]

--- a/src/tradingo/sampling/instruments.py
+++ b/src/tradingo/sampling/instruments.py
@@ -47,7 +47,9 @@ def download_instruments(
     if tickers:
         return (
             (
-                pd.DataFrame({t: Ticker(currency_to_symbol(t)).get_info() for t in tickers})
+                pd.DataFrame(
+                    {t: Ticker(currency_to_symbol(t)).get_info() for t in tickers}
+                )
                 .transpose()
                 .rename_axis("Symbol")
             ),

--- a/src/tradingo/sampling/instruments.py
+++ b/src/tradingo/sampling/instruments.py
@@ -7,6 +7,7 @@ import pandas as pd
 from yfinance import Ticker
 
 from tradingo.sampling.ig import get_ig_service
+from tradingo.sampling.yf import currency_to_symbol
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +47,7 @@ def download_instruments(
     if tickers:
         return (
             (
-                pd.DataFrame({t: Ticker(t).get_info() for t in tickers})
+                pd.DataFrame({t: Ticker(currency_to_symbol(t)).get_info() for t in tickers})
                 .transpose()
                 .rename_axis("Symbol")
             ),

--- a/src/tradingo/sampling/yf.py
+++ b/src/tradingo/sampling/yf.py
@@ -37,6 +37,7 @@ def symbol_to_currency(symbol: str) -> str:
         return symbol[:-2]
     return symbol
 
+
 def _get_ticker(ticker: str) -> str:
     if (ticker_ := currency_to_symbol(ticker)) != ticker:
         logger.info("converting currency ticker %s to %s", ticker, ticker_)

--- a/test/tradingo/test_sampling.py
+++ b/test/tradingo/test_sampling.py
@@ -1,0 +1,27 @@
+import pytest
+
+from tradingo.sampling.yf import currency_to_symbol, symbol_to_currency
+
+
+def test_handle_currency_ticker_valid_ticker():
+    symbols = "USDJPY=X"
+    result = symbol_to_currency(symbols)
+    assert (
+        result == "USDJPY"
+    ), "The ticker should be correctly converted to currency pair."
+
+
+def test_handle_currency():
+    ticker = "GBPUSD"
+    result = currency_to_symbol(ticker)
+    assert result == "GBPUSD=X", "The ticker is a currency pair, whould end by =X."
+
+
+def test_handle_not_a_currency():
+    ticker = "NOTCCY"
+    result = currency_to_symbol(ticker)
+    assert result == "NOTCCY", "The ticker is not a currency pair."
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
add currency ticker handling for yfinance as `=` is not an allowed char in task_id
(yf's ccy format is `AAABBB=X` - not sure why they have a self inflicted `=X` postfix