### PR TITLE
Normalize timezones to UTC in yf.create_universe

### DIFF
--- a/src/tradingo/sampling/yf.py
+++ b/src/tradingo/sampling/yf.py
@@ -126,7 +126,14 @@ def create_universe(
         item = cast(
             VersionedItem, pricelib.read(symbol, date_range=(start_date, end_date))
         )
-        return pd.DataFrame(item.data)
+        df = pd.DataFrame(item.data)
+        if isinstance(df.index, pd.DatetimeIndex):
+            df.index = (
+                df.index.tz_localize("UTC")
+                if df.index.tz is None
+                else df.index.tz_convert("UTC")
+            )
+        return df
 
     available_symbols = pricelib.list_symbols()
     if missing_symbol := set(instruments.index.difference(available_symbols)):

--- a/test/tradingo/test_sampling.py
+++ b/test/tradingo/test_sampling.py
@@ -244,6 +244,72 @@ class TestConvertPricesToCcy:
         assert isinstance(result[0], pd.DataFrame)
 
 
+class TestCreateUniverse:
+    """Tests for create_universe function."""
+
+    @staticmethod
+    def _make_ohlcv(index: pd.DatetimeIndex) -> pd.DataFrame:
+        return pd.DataFrame(
+            {
+                "Open": [1.0] * len(index),
+                "High": [1.0] * len(index),
+                "Low": [1.0] * len(index),
+                "Close": [1.0] * len(index),
+                "Volume": [1.0] * len(index),
+            },
+            index=index,
+        )
+
+    def _make_pricelib(self, data_by_symbol: dict[str, pd.DataFrame]) -> MagicMock:
+        pricelib = MagicMock()
+        pricelib.list_symbols.return_value = list(data_by_symbol.keys())
+
+        def read(symbol: str, date_range: Any = None) -> MagicMock:
+            item = MagicMock()
+            item.data = data_by_symbol[symbol]
+            return item
+
+        pricelib.read.side_effect = read
+        return pricelib
+
+    def test_mixed_tz_naive_and_aware_symbols_concat(self) -> None:
+        """A tz-naive symbol must not break concat with tz-aware symbols."""
+        naive_idx = pd.date_range("2024-01-01", periods=3, freq="D")
+        aware = self._make_ohlcv(naive_idx.tz_localize("UTC"))
+        naive = self._make_ohlcv(naive_idx)
+        pricelib = self._make_pricelib({"AAA": aware, "BBB": naive})
+        instruments = pd.DataFrame(index=pd.Index(["AAA", "BBB"], name="ticker"))
+
+        open_, *_ = getattr(create_universe, "__wrapped__")(
+            pricelib=pricelib,
+            instruments=instruments,
+            end_date=None,
+            start_date=None,
+        )
+
+        assert isinstance(open_.index, pd.DatetimeIndex)
+        assert str(open_.index.tz) == "UTC"
+        assert list(open_.columns) == ["AAA", "BBB"]
+
+    def test_non_utc_tz_converted_to_utc(self) -> None:
+        """A non-UTC tz-aware symbol is converted to UTC."""
+        ny_idx = pd.date_range("2024-01-01", periods=2, freq="D", tz="US/Eastern")
+        utc_idx = pd.date_range("2024-01-01", periods=2, freq="D", tz="UTC")
+        pricelib = self._make_pricelib(
+            {"NY": self._make_ohlcv(ny_idx), "UTC": self._make_ohlcv(utc_idx)}
+        )
+        instruments = pd.DataFrame(index=pd.Index(["NY", "UTC"], name="ticker"))
+
+        open_, *_ = getattr(create_universe, "__wrapped__")(
+            pricelib=pricelib,
+            instruments=instruments,
+            end_date=None,
+            start_date=None,
+        )
+
+        assert str(open_.index.tz) == "UTC"
+
+
 # =============================================================================
 # IG Trading Tests (ig.py)
 # =============================================================================


### PR DESCRIPTION
## Summary
- `pd.concat` in `yf.create_universe` was raising `Cannot join tz-naive with tz-aware DatetimeIndex` whenever Arctic contained a mix of tz-aware and tz-naive daily bars — bricking the whole universe task.
- Localize naive indexes as UTC and convert tz-aware ones to UTC before concat, matching the convention already used in `sample_equity` (yf.py:96-101).

## Context
Audit of `prices_relative_sharpe` in prod:
- **17/19 symbols** are tz-aware UTC and fresh — equities and FX work fine.
- **2 outliers** stored tz-naive (last updated early March): `JNKE.L` (bonds) and `0P0001QJ9W.L` (alternatives). yfinance currently returns tz-naive indexes for these and `sample_equity`'s tz-localize branch isn't catching them (likely upstream sampling is failing for another reason — worth a separate Airflow log dive).
- A single stale tz-naive symbol was enough to break the concat for the entire universe.

UTC is already the storage convention — this just makes `create_universe` defensive against stale symbols so one bad ticker can't take down the whole pipeline.

## Test plan
- [x] New `TestCreateUniverse::test_mixed_tz_naive_and_aware_symbols_concat` — reproduces the prod failure, passes with the fix.
- [x] New `TestCreateUniverse::test_non_utc_tz_converted_to_utc` — verifies non-UTC tz-aware symbols are converted.
- [x] `uv run pytest` — 235 passed.
- [x] black / ruff / mypy / isort — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)