### PR TITLE
fix: make symbol_publisher the unconditional task envelope

### DIFF
--- a/src/tradingo/dag.py
+++ b/src/tradingo/dag.py
@@ -70,11 +70,10 @@ class Task:
             importlib.import_module(module), function_name
         )
 
-        if self.symbols_out:
-            function = symbols.symbol_publisher(
-                *self.symbols_out,
-                **self.publish_args,
-            )(function)
+        function = symbols.symbol_publisher(
+            *self.symbols_out,
+            **self.publish_args,
+        )(function)
 
         if self.symbols_in:
             function = symbols.symbol_provider(

--- a/src/tradingo/symbols.py
+++ b/src/tradingo/symbols.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 P = ParamSpec("P")
 Q = ParamSpec("Q")
-R = TypeVar("R", pd.DataFrame, tuple[pd.DataFrame, ...])
+R = TypeVar("R", pd.DataFrame, tuple[pd.DataFrame, ...], None)
 
 ROpt = TypeVar(
     "ROpt",
@@ -393,13 +393,25 @@ def symbol_publisher(
         ) -> pd.DataFrame | None:
             if args:
                 raise ValueError("Keyword only arguments.")
-            out: tuple[pd.DataFrame, ...] | pd.DataFrame = _envoke_symbology_function(
-                func,
-                arctic,
-                start_date=kwargs.pop("start_date", None),
-                end_date=kwargs.pop("end_date", None),
-                **kwargs,
+            out: tuple[pd.DataFrame, ...] | pd.DataFrame | None = (
+                _envoke_symbology_function(
+                    func,
+                    arctic,
+                    start_date=kwargs.pop("start_date", None),
+                    end_date=kwargs.pop("end_date", None),
+                    **kwargs,
+                )
             )
+
+            # No-publish task (sentinel/check). The publisher is the task
+            # envelope: it has consumed dry_run/snapshot/clean above so they
+            # don't leak into the inner function. With nothing to write,
+            # forward whatever the function returned (typically None).
+            if not symbols and not template:
+                return out  # type: ignore[return-value]
+
+            # Publishing implies the function produced data.
+            assert out is not None
             if not isinstance(out, (tuple, list)):
                 out = (out,)
 

--- a/test/tradingo/test_cli.py
+++ b/test/tradingo/test_cli.py
@@ -155,19 +155,20 @@ def dummy_task(
     name: str,
     start_date: pd.Timestamp | None = None,
     end_date: pd.Timestamp | None = None,
-    dry_run: bool = False,
-    clean: bool = False,
     **kwargs: Any,
 ) -> None:
-    """A dummy task that records its execution."""
+    """A dummy task that records its execution.
+
+    Intentionally does not declare ``dry_run`` / ``snapshot`` / ``clean``:
+    those are task-envelope kwargs owned by ``symbol_publisher`` and must
+    never reach the inner function. ``**kwargs`` captures any leaks.
+    """
     _executed_tasks.append(
         {
             "name": name,
             "task_name": name,  # Alias for compatibility
             "start_date": start_date,
             "end_date": end_date,
-            "dry_run": dry_run,
-            "clean": clean,
             "kwargs": kwargs,
         }
     )
@@ -998,7 +999,8 @@ class TestTaskRunCommand:
     def test_run_task_with_dry_run(
         self, simple_config: dict[str, Any], tmp_path: Path
     ) -> None:
-        """Run a task with dry_run flag."""
+        """``dry_run`` is owned by the publisher envelope and must not leak
+        into the inner function."""
         args = argparse.Namespace(
             config=simple_config,
             entity="task",
@@ -1018,12 +1020,14 @@ class TestTaskRunCommand:
             handle_tasks(args, arctic)
 
         assert len(_executed_tasks) == 1
-        assert _executed_tasks[0]["dry_run"] is True
+        assert "dry_run" not in _executed_tasks[0]["kwargs"]
+        assert "snapshot" not in _executed_tasks[0]["kwargs"]
 
     def test_run_task_with_clean(
         self, simple_config: dict[str, Any], tmp_path: Path
     ) -> None:
-        """Run a task with clean flag."""
+        """``clean`` is owned by the publisher envelope and must not leak
+        into the inner function."""
         args = argparse.Namespace(
             config=simple_config,
             entity="task",
@@ -1043,7 +1047,7 @@ class TestTaskRunCommand:
             handle_tasks(args, arctic)
 
         assert len(_executed_tasks) == 1
-        assert _executed_tasks[0]["clean"] is True
+        assert "clean" not in _executed_tasks[0]["kwargs"]
 
     def test_run_task_with_skip_deps(
         self, simple_config: dict[str, Any], tmp_path: Path

--- a/test/tradingo/test_symbols.py
+++ b/test/tradingo/test_symbols.py
@@ -328,6 +328,24 @@ def test_symbol_provider_with_columns_query_param(arctic: Arctic) -> None:
 # =============================================================================
 
 
+def test_symbol_publisher_no_symbols_acts_as_envelope(arctic: Arctic) -> None:
+    """Publisher with no symbols (sentinel/check task) consumes
+    dry_run/snapshot/clean and dispatches to the inner function without
+    leaking those kwargs into its signature."""
+
+    captured: dict[str, object] = {}
+
+    @symbol_publisher()
+    def check(value: int) -> None:
+        captured["value"] = value
+        return None
+
+    result = check(arctic=arctic, value=7, dry_run=False, snapshot="snap", clean=True)
+
+    assert result is None
+    assert captured == {"value": 7}
+
+
 def test_symbol_publisher_dry_run_returns_concat(arctic: Arctic) -> None:
     @symbol_publisher("lib1/sym1", "lib2/sym2")
     def publisher() -> tuple[pd.DataFrame, pd.DataFrame]:


### PR DESCRIPTION
So `dry_run` / `snapshot` / `clean` don't leak into sentinel tasks (e.g. `check_price_staleness`).